### PR TITLE
Fixed Issues link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,6 @@ This dynamic visualization allows the user to customize some different views and
 
 ## 3. Contributing to this visualization code
 If you wish to improve or enhance this code or if you find errors or bugs, please consider the following ways to contribute to this project.
-* Browse the repository [Issues](issues) for known areas that need attention.
-* Submit questions or suggestions by submitting a new issue in the repository [Issues](issues).
+* Browse the repository [Issues](https://github.com/OpenSourceEcon/USempl_NormPeakPlot/issues) for known areas that need attention.
+* Submit questions or suggestions by submitting a new issue in the repository [Issues](https://github.com/OpenSourceEcon/USempl_NormPeakPlot/issues).
 * Submit a pull request with your proposed changes.


### PR DESCRIPTION
This PR fixes the "Issues" link at the end of the `README.md`. I had initially set this to a relative link, but I have not found a way to do it for Issues in GitHub markdown. So this version simply pastes the entire link.